### PR TITLE
Add send CAS and Learning Objectives as JSON feature

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,10 +13,10 @@ method-rgx=^([_a-z][a-z0-9_]*|__[a-z0-9]+__)$
 const-rgx=^(([A-Z_][A-Z0-9_]*)|(__.*__)|([a-z_]+_models)|([a-z_]+_services))$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=e,_,d,f,i,l,p,w,fn,fs,id,pc,sc,zf,setUp,tearDown,longMessage,maxDiff
+good-names=e,_,d,c,f,i,l,p,w,fn,fs,id,pc,sc,zf,setUp,tearDown,longMessage,maxDiff
 
 # Regex for dummy variables (to prevent 'unused argument' errors)
-dummy-variables-rgx=_|unused_*
+dummy-variables-rgx=_|unused_*|request|args|kwargs
 
 # Ignore files or directories
 ignore=migrations

--- a/journal/files/DESCRIPTION.md
+++ b/journal/files/DESCRIPTION.md
@@ -1,0 +1,9 @@
+### Description
+This directory is where all non-static files related to journal should reside.
+These files are not models, views, serializers, tests, templates, migrations,
+etc but are files that are non-python needed for the app to function. It is
+important to note that these files are **not** served to the user directly.
+
+### Contents
+- cas.csv
+- learning_objectives.csv

--- a/journal/files/cas.csv
+++ b/journal/files/cas.csv
@@ -1,0 +1,3 @@
+0,Creativity
+1,Action
+2,Service

--- a/journal/files/learning_objectives.csv
+++ b/journal/files/learning_objectives.csv
@@ -1,0 +1,8 @@
+0,Increased awareness of strengths and areas for growth
+1,Undertaking new challenges
+2,Planned and initiated activities
+3,Working collaboratively with others
+4,Showing perseverance and commitment
+5,Engaged with issues of global importance
+6,Consideration of ethical implications
+7,Developing new skills

--- a/journal/templates/journal/home.html
+++ b/journal/templates/journal/home.html
@@ -4,6 +4,12 @@
     <title>Hi!</title>
   </head>
   <body>
-    <h1>Hi!</h1>
+    <h1>{{ text }}</h1>
+    The following links are avalible to use:
+    <ul>
+    {% for link in links %}
+        <li> <a href="{{ link }}">{{ link }}</a> </li>
+    {% endfor %}
+    </ul>
   </body>
 </html>

--- a/journal/tests/test_category_type.py
+++ b/journal/tests/test_category_type.py
@@ -1,0 +1,39 @@
+from django.test import Client
+from django.test import TestCase
+
+class CategoryTestCase(TestCase):
+    def test_cas_category(self):
+        """Test to ensure that CAS categories can be rendered properly"""
+        c = Client()
+        response = c.get('/categories/cas')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['0'], 'Creativity')
+        self.assertEqual(response.json()['1'], 'Action')
+        self.assertEqual(response.json()['2'], 'Service')
+
+    def test_learning_objectives(self):
+        """Test to ensure that learning objectives can be rendered properly"""
+        c = Client()
+        response = c.get('/categories/learning_objectives')
+        self.assertEqual(response.status_code, 200)
+
+        learning_objectives = [
+            'Increased awareness of strengths and areas for growth',
+            'Undertaking new challenges',
+            'Planned and initiated activities',
+            'Working collaboratively with others',
+            'Showing perseverance and commitment',
+            'Engaged with issues of global importance',
+            'Consideration of ethical implications',
+            'Developing new skills'
+        ]
+        for ind, _ in enumerate(learning_objectives):
+            self.assertEqual(response.json()['{0}'.format(ind)],
+                             learning_objectives[ind])
+
+    def test_invalid_category_request(self):
+        """Test to ensure that server will throw a 404 if given a bad argument
+        """
+        c = Client()
+        response = c.get('/categories/learning_objectivess')
+        self.assertEqual(response.status_code, 404)

--- a/journal/urls.py
+++ b/journal/urls.py
@@ -5,4 +5,6 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.HomeView.as_view(), name='home'),
+    url(r'^categories/(?P<category>\w+)', views.CategoryJSONView.as_view(),
+        name='activity_type'),
 ]

--- a/journal/views/__init__.py
+++ b/journal/views/__init__.py
@@ -1,0 +1,2 @@
+from .home_view import HomeView
+from .category_view import CategoryJSONView

--- a/journal/views/category_view.py
+++ b/journal/views/category_view.py
@@ -1,0 +1,43 @@
+import csv
+import os
+from django.http import JsonResponse
+from django.http import HttpResponseNotFound, HttpResponseBadRequest
+from django.views.generic import View
+
+_CATEGORY_TYPES = ['cas', 'learning_objectives']
+_CSV_FILE_DIR = os.path.join(os.getcwd(), 'journal', 'files')
+
+class CategoryJSONView(View):
+
+    def _get_categories_from_file(self, category):
+        """
+        Outputs a dictionary of the particular category type. CSV files
+        are expected to have the following format:
+
+        1,Creativity
+        2,Action
+        3,Service
+        """
+        category = str(category)
+        assert category in _CATEGORY_TYPES, 'Category must be in approved \
+                                            category types!'
+        types = {}
+        file_name = os.path.join(_CSV_FILE_DIR, '{0}.csv'.format(category))
+        with open(file_name) as csvfile:
+            reader = csv.reader(csvfile)
+            for row in reader:
+                types[row[0]] = row[1]
+        return types
+
+
+    def get(self, request, *args, **kwargs):
+        """Gets the associated JSON for the Category types. Will return a 404
+        a non-valid category is given"""
+        assert kwargs['category'] != None, HttpResponseBadRequest(
+            'Must provide category!')
+
+        if kwargs['category'] in _CATEGORY_TYPES:
+            result = self._get_categories_from_file(kwargs['category'])
+            return JsonResponse(result)
+        else:
+            return HttpResponseNotFound('Category not found!')

--- a/journal/views/category_view.py
+++ b/journal/views/category_view.py
@@ -26,7 +26,8 @@ class CategoryJSONView(View):
         with open(file_name) as csvfile:
             reader = csv.reader(csvfile)
             for row in reader:
-                types[row[0]] = row[1]
+                index, category = row
+                types[index] = category
         return types
 
 

--- a/journal/views/home_view.py
+++ b/journal/views/home_view.py
@@ -9,4 +9,5 @@ class HomeView(TemplateView):
 
     def get(self, request):
         """Returns the home page"""
-        return render(request, self.template_name, locals())
+        links = ['/categories/cas', '/categories/learning_objectives']
+        return render(request, self.template_name, {'links': links})

--- a/scripts/linter.py
+++ b/scripts/linter.py
@@ -8,9 +8,10 @@ def run_py_lint(config):
                              stderr=subprocess.PIPE)
     cas = subprocess.run(['pylint', 'cas/', options], stderr=subprocess.PIPE)
     if journal.returncode or cas.returncode:
+        print('There are 1 (or more) python linting error(s).')
         sys.exit(1)
     return
 
 if __name__ == '__main__':
     run_py_lint('.pylintrc')
-    print('Linting complete')
+    print('Lint check complete.')


### PR DESCRIPTION
This commit introduces the feature of sending CAS types and Learning Objectives
as JSON files to the front when a get request is recieved by the server. As
a result, a new file directory has been introduced to support this feature, as
it contains all of the supporting csv files for this feature. With the
associated urls update. Tests have also been updated to reflect this feature.
Home page is updated to now show the avalible links to the developer to use.

Addresses #4 
